### PR TITLE
Fix to read data even if stdin is a stream

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -26,6 +26,7 @@ long readFile(char *name, void **buffer) {
         }
     }
     
+    *buffer = malloc(sizeof chunk);
     while ((bytesRead = fread(chunk, 1, sizeof chunk, file)) > 0) {
         unsigned char *reallocated = realloc(*buffer, fileLen + bytesRead);
         if (reallocated) {


### PR DESCRIPTION
If, stdin is not a file, it is neither redirection file, if data is streaming,
It is erro such as:

``` bash
$ convert input.png jpeg:- | ./jpeg-recompress - output.jpg
Only able to read 123824 bytes!
```

This PR will fix to read the input data in such cases.
