### PR TITLE
updates for mozjpeg-3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ before_install:
     - sudo apt-get install -qq build-essential autoconf nasm
     - git clone https://github.com/mozilla/mozjpeg.git
     - cd mozjpeg
-    - git checkout 7faa703ebf7360e5c0a37d71a74c293232998340
+    - git fetch origin refs/tags/v3.0:refs/tags/v3.0
+    - git fetch --all
+    - git checkout tags/v3.0
     - autoreconf -fiv
     - ./configure --with-jpeg8
     - make && sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
     - sudo apt-get install -qq build-essential autoconf nasm
     - git clone https://github.com/mozilla/mozjpeg.git
     - cd mozjpeg
-    - git checkout tags/v3.0
+    - git checkout 7faa703ebf7360e5c0a37d71a74c293232998340
     - autoreconf -fiv
     - ./configure --with-jpeg8
     - make && sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
     - sudo apt-get install -qq build-essential autoconf nasm
     - git clone https://github.com/mozilla/mozjpeg.git
     - cd mozjpeg
-    - git checkout bf061b4a1ca4d2f9a6c29262d62500971c1cd884
+    - git checkout tags/v3.0
     - autoreconf -fiv
     - ./configure --with-jpeg8
     - make && sudo make install

--- a/Makefile
+++ b/Makefile
@@ -3,23 +3,24 @@ CFLAGS += -std=c99 -Wall -O3
 LDFLAGS += -lm
 MAKE ?= make
 PREFIX ?= /usr/local
+MOZJPEG_PREFIX ?= /opt/mozjpeg
 
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
 
 ifeq ($(UNAME_S),Linux)
 	# Linux (e.g. Ubuntu)
-	CFLAGS += -I/opt/mozjpeg/include
+	CFLAGS += -I$(MOZJPEG_PREFIX)/include
 	ifeq ($(UNAME_M),x86_64)
-		LIBJPEG = /opt/mozjpeg/lib64/libjpeg.a
+		LIBJPEG = $(MOZJPEG_PREFIX)/lib64/libjpeg.a
 	else
-		LIBJPEG = /opt/mozjpeg/lib/libjpeg.a
+		LIBJPEG = $(MOZJPEG_PREFIX)/lib/libjpeg.a
 	endif
 else
 	ifeq ($(UNAME_S),Darwin)
 		# Mac OS X
-		LIBJPEG = /opt/mozjpeg/lib/libjpeg.a
-		CFLAGS += -I/opt/mozjpeg/include
+		LIBJPEG = $(MOZJPEG_PREFIX)/lib/libjpeg.a
+		CFLAGS += -I$(MOZJPEG_PREFIX)/include
 	else
 		# Windows
 		LIBJPEG = ../mozjpeg/libjpeg.a

--- a/Makefile
+++ b/Makefile
@@ -9,17 +9,17 @@ UNAME_M := $(shell uname -m)
 
 ifeq ($(UNAME_S),Linux)
 	# Linux (e.g. Ubuntu)
-	CFLAGS += -I/opt/libmozjpeg/include
+	CFLAGS += -I/opt/mozjpeg/include
 	ifeq ($(UNAME_M),x86_64)
-		LIBJPEG = /opt/libmozjpeg/lib64/libjpeg.a
+		LIBJPEG = /opt/mozjpeg/lib64/libjpeg.a
 	else
-		LIBJPEG = /opt/libmozjpeg/lib/libjpeg.a
+		LIBJPEG = /opt/mozjpeg/lib/libjpeg.a
 	endif
 else
 	ifeq ($(UNAME_S),Darwin)
 		# Mac OS X
-		LIBJPEG = /usr/local/opt/mozjpeg/lib/libjpeg.a
-		CFLAGS += -I/usr/local/opt/mozjpeg/include
+		LIBJPEG = /opt/mozjpeg/lib/libjpeg.a
+		CFLAGS += -I/opt/mozjpeg/include
 	else
 		# Windows
 		LIBJPEG = ../mozjpeg/libjpeg.a

--- a/src/util.c
+++ b/src/util.c
@@ -124,17 +124,15 @@ unsigned long encodeJpeg(unsigned char **jpeg, unsigned char *buf, int width, in
     cinfo.input_components = pixelFormat == JCS_RGB ? 3 : 1;
     cinfo.in_color_space = pixelFormat;
 
-    if (optimize) {
-        cinfo.use_moz_defaults = TRUE;
-    }
-
     jpeg_set_defaults(&cinfo);
 
     if (optimize && !progressive) {
         // Moz defaults, disable progressive
         cinfo.scan_info = NULL;
         cinfo.num_scans = 0;
-        cinfo.optimize_scans = FALSE;
+        if (jpeg_c_bool_param_supported(&cinfo, JBOOLEAN_OPTIMIZE_SCANS)) {
+            jpeg_c_set_bool_param(&cinfo, JBOOLEAN_OPTIMIZE_SCANS, FALSE);
+        }
     }
 
     if (!optimize && progressive) {


### PR DESCRIPTION
This builds against mozjpeg 3.0, and should achieve the same ends (see #17).

`cinfo.use_moz_defaults` has been removed, but it seems that if you haven't explicitly set something different, you get the old defaults without setting anything and the `jpeg_simple_progression` call below in the `!optimize && progressive` block should turn them off.