### PR TITLE
Missing apt package: pkg-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,13 @@ Building
 Ubuntu users can install via `apt-get`:
 
 ```bash
-$ sudo apt-get install build-essential autoconf nasm libtool
-$ git clone https://github.com/mozilla/mozjpeg.git
-$ cd mozjpeg
-$ autoreconf -fiv
-$ ./configure --with-jpeg8
-$ make
-$ sudo make install
+sudo apt-get install build-essential autoconf pkg-config nasm libtool
+git clone https://github.com/mozilla/mozjpeg.git
+cd mozjpeg
+autoreconf -fiv
+./configure --with-jpeg8
+make
+sudo make install
 ```
 
 #### Mac OS X


### PR DESCRIPTION
See: https://github.com/mozilla/mozjpeg/issues/99
I hope your are happy with removing `$` signs. This way it can be copy-and-pasted.