### PR TITLE
Fix bash IF 'unary operator expected' error by doubling the statement's brackets

### DIFF
--- a/jpeg-archive
+++ b/jpeg-archive
@@ -6,7 +6,7 @@
 #   $ jpeg-archive
 # Compressed JPEGs are now in ./Comp/*
 
-if [ $1 == '--help' ]; then
+if [[ $1 == '--help' ]]; then
     echo 'JPEG-Archive - Compress RAW and JPEG images in the current folder'
     echo 'Usage: jpeg-archive [options]'
     echo ''
@@ -15,7 +15,7 @@ if [ $1 == '--help' ]; then
     exit 255
 fi
 
-if [ $1 == '--version' ]; then
+if [[ $1 == '--version' ]]; then
     jpeg-recompress --version
     exit 255
 fi


### PR DESCRIPTION
I was seeing the error:
`/usr/local/bin/jpeg-archive: line 9: [: ==: unary operator expected
/usr/local/bin/jpeg-archive: line 18: [: ==: unary operator expected`
on OS X.

Simply doubling the IF statement's brackets fixes this.