### PR TITLE
Ignore empty lines in PPM header

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -223,8 +223,8 @@ unsigned long decodePpm(unsigned char *buf, unsigned long bufSize, unsigned char
     // Read to first newline
     while (buf[pos++] != '\n') {}
 
-    // Discard for any comment lines
-    while (buf[pos] == '#') {
+    // Discard for any comment and empty lines
+    while (buf[pos] == '#' || buf[pos] == '\n') {
         while (buf[pos] != '\n') {
             pos++;
         }


### PR DESCRIPTION
This fixes parsing PPMs generated by [libvips](https://github.com/jcupitt/libvips) which look like:

    P6
    #vips2ppm - Tue Apr 26 15:21:28 2016

    2600 1268
    255