### PR TITLE
Create a recompress library to embedding in other sources

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*.{h,c}]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.exe
 src/*.o
 src/iqa/.svn
 src/iqa/build

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ all: jpeg-recompress jpeg-compare jpeg-hash
 $(LIBIQA):
 	cd src/iqa; RELEASE=1 $(MAKE)
 
-jpeg-recompress: jpeg-recompress.c src/util.o src/edit.o src/smallfry.o src/commander.o $(LIBIQA)
+jpeg-recompress: jpeg-recompress.c src/util.o src/edit.o src/smallfry.o src/commander.o src/recompress.o $(LIBIQA)
 	$(CC) $(CFLAGS) -o $@ $^ $(LIBJPEG) $(LDFLAGS)
 
 jpeg-compare: jpeg-compare.c src/util.o src/hash.o src/edit.o src/commander.o  src/smallfry.o $(LIBIQA)

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,17 @@ MAKE ?= make
 PREFIX ?= /usr/local
 
 UNAME_S := $(shell uname -s)
+LBITS := $(shell getconf LONG_BIT)
 
 ifeq ($(UNAME_S),Linux)
 	# Linux (e.g. Ubuntu)
 	MOZJPEG_PREFIX ?= /opt/mozjpeg
 	CFLAGS += -I$(MOZJPEG_PREFIX)/include
-	LIBJPEG = $(MOZJPEG_PREFIX)/lib/libjpeg.a
+	ifeq ($(LBITS),64)
+		LIBJPEG = $(MOZJPEG_PREFIX)/lib64/libjpeg.a
+	else
+		LIBJPEG = $(MOZJPEG_PREFIX)/lib/libjpeg.a
+	endif
 else ifeq ($(UNAME_S),Darwin)
 	# Mac OS X
 	MOZJPEG_PREFIX ?= /usr/local/opt/mozjpeg

--- a/jpeg-recompress.c
+++ b/jpeg-recompress.c
@@ -168,7 +168,7 @@ int main (int argc, char **argv) {
 
     if (!res) {
         int code = (*error)->statusCode;
-        fprintf(stderr, (*error)->message);
+        fprintf(stderr, "%s\n", (*error)->message);
         free(*error);
         free(error);
         return code;

--- a/jpeg-recompress.c
+++ b/jpeg-recompress.c
@@ -4,26 +4,12 @@
     between JPEG quality 40 and 95 to find the best match. Also makes sure
     that huffman tables are optimized if they weren't already.
 */
-#include <assert.h>
-#include <stdarg.h>
 #include <stdio.h>
-#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "src/commander.h"
-#include "src/edit.h"
-#include "src/iqa/include/iqa.h"
 #include "src/recompress.h"
-#include "src/smallfry.h"
-#include "src/util.h"
-
-#ifdef _WIN32
-    #include <io.h>
-    #include <fcntl.h>
-#endif
-
-const char *COMMENT = "Compressed by jpeg-recompress";
 
 recompress_options_t options = {
     .method = METHOD_SSIM,
@@ -126,62 +112,6 @@ static void setAccurate(command_t *self) {
     options.accurate = true;
 }
 
-static float getTargetFromPreset(enum METHOD method,
-                                 enum QUALITY_PRESET preset) {
-    switch (method) {
-        case METHOD_SSIM:
-            switch (preset) {
-                case QUALITY_LOW:
-                    return 0.999;
-                case QUALITY_MEDIUM:
-                    return 0.9999;
-                case QUALITY_HIGH:
-                    return 0.99995;
-                case QUALITY_VERYHIGH:
-                    return 0.99999;
-            }
-            break;
-        case METHOD_MS_SSIM:
-            switch (preset) {
-                case QUALITY_LOW:
-                    return 0.85;
-                case QUALITY_MEDIUM:
-                    return 0.94;
-                case QUALITY_HIGH:
-                    return 0.96;
-                case QUALITY_VERYHIGH:
-                    return 0.98;
-            }
-            break;
-        case METHOD_SMALLFRY:
-            switch (preset) {
-                case QUALITY_LOW:
-                    return 100.75;
-                case QUALITY_MEDIUM:
-                    return 102.25;
-                case QUALITY_HIGH:
-                    return 103.8;
-                case QUALITY_VERYHIGH:
-                    return 105.5;
-            }
-            break;
-        case METHOD_MPE:
-            switch (preset) {
-                case QUALITY_LOW:
-                    return 1.5;
-                case QUALITY_MEDIUM:
-                    return 1.0;
-                case QUALITY_HIGH:
-                    return 0.8;
-                case QUALITY_VERYHIGH:
-                    return 0.6;
-            }
-            break;
-    }
-    assert(("should be unreachable. All cases handled?",0));
-    return 0.0;
-}
-
 static void setSubsampling(command_t *self) {
     if (!strcmp("default", self->arg)) {
         options.subsample = SUBSAMPLE_DEFAULT;
@@ -196,48 +126,7 @@ static void setQuiet(command_t *self) {
     options.quiet = true;
 }
 
-// Open a file for writing
-FILE *openOutput(char *name) {
-    if (strcmp("-", name) == 0) {
-        #ifdef _WIN32
-            setmode(fileno(stdout), O_BINARY);
-        #endif
-
-        return stdout;
-    } else {
-        return fopen(name, "wb");
-    }
-}
-
-// Logs an informational message, taking quiet mode into account
-void info(const char *format, ...) {
-    va_list argptr;
-
-    if (!options.quiet) {
-        va_start(argptr, format);
-        vfprintf(stderr, format, argptr);
-        va_end(argptr);
-    }
-}
-
 int main (int argc, char **argv) {
-    enum filetype inputFiletype = FILETYPE_UNKNOWN;
-    unsigned char *buf;
-    long bufSize = 0;
-    unsigned char *original;
-    long originalSize = 0;
-    unsigned char *originalGray = NULL;
-    long originalGraySize = 0;
-    unsigned char *compressed = NULL;
-    unsigned long compressedSize = 0;
-    unsigned char *compressedGray;
-    long compressedGraySize = 0;
-    unsigned char *tmpImage;
-    int width, height;
-    unsigned char *metaBuf;
-    unsigned int metaSize = 0;
-    FILE *file;
-
     // Parse commandline options
     command_t cmd;
     command_init(&cmd, argv[0], VERSION);
@@ -271,247 +160,20 @@ int main (int argc, char **argv) {
         return 255;
     }
 
-    // No target passed, use preset!
-    if (!options.target) {
-        options.target = getTargetFromPreset(options.method, options.preset);
-    }
-
-    /* Detect input file type. */
-    if (options.inputFiletype == FILETYPE_AUTO) {
-        inputFiletype = detectFiletype((char *)cmd.argv[0]);
-    } else {
-        inputFiletype = options.inputFiletype;
-    }
-
-    /*
-     * Read original image and decode. We need the raw buffer contents and its
-     * size to obtain meta data and the original file size later.
-     */
-    bufSize = readFile((char *) cmd.argv[0], (void **) &buf);
-    originalSize = decodeFile((char *) cmd.argv[0], &original, inputFiletype, &width, &height, JCS_RGB);
-    if (!originalSize) {
-        fprintf(stderr, "invalid input file: %s\n", cmd.argv[0]);
-        return 1;
-    }
-
-    if (options.defishStrength) {
-        info("Defishing...\n");
-        tmpImage = malloc(width * height * 3);
-        defish(original, tmpImage, width, height, 3, options.defishStrength,
-               options.defishZoom);
-        free(original);
-        original = tmpImage;
-    }
-
-    // Convert RGB input into Y
-    originalGraySize = grayscale(original, &originalGray, width, height);
-
-    if (inputFiletype == FILETYPE_JPEG) {
-        // Read metadata (EXIF / IPTC / XMP tags)
-        if (getMetadata(buf, bufSize, &metaBuf, &metaSize, COMMENT)) {
-            if (options.copyFiles) {
-                info("File already processed by jpeg-recompress!\n");
-                file = openOutput(cmd.argv[1]);
-                if (file == NULL) {
-                    fprintf(stderr, "Could not open output file.");
-                    return 1;
-                }
-
-                fwrite(buf, bufSize, 1, file);
-                fclose(file);
-
-                free(buf);
-
-                return 0;
-            } else {
-                fprintf(stderr, "File already processed by jpeg-recompress!\n");
-                free(buf);
-                return 2;
-            }
-        }
-    }
-
-    if (options.strip) {
-        // Pretend we have no metadata
-        metaSize = 0;
-    } else {
-        info("Metadata size is %ukb\n", metaSize / 1024);
-    }
-
-    if (!originalSize || !originalGraySize) { return 1; }
-
-    // Do a binary search to find the optimal encoding quality for the
-    // given target SSIM value.
-    int min = options.jpegMin, max = options.jpegMax;
-    for (int attempt = options.attempts - 1; attempt >= 0; --attempt) {
-        float metric;
-        int quality = min + (max - min) / 2;
-        int progressive = attempt ? 0 : !options.noProgressive;
-        int optimize = options.accurate ? 1 : (attempt ? 0 : 1);
-
-        // Recompress to a new quality level, without optimizations (for speed)
-        compressedSize = encodeJpeg(&compressed, original, width, height,
-                                    JCS_RGB, quality, progressive, optimize,
-                                    options.subsample);
-
-        // Load compressed luma for quality comparison
-        compressedGraySize = decodeJpeg(compressed, compressedSize, &compressedGray, &width, &height, JCS_GRAYSCALE);
-
-        if (!compressedGraySize) {
-          fprintf(stderr, "Unable to decode file that was just encoded!\n");
-          return 1;
-        }
-
-        if (!attempt) {
-            info("Final optimized ");
-        }
-
-        // Measure quality difference
-        switch (options.method) {
-            case METHOD_MS_SSIM:
-                metric = iqa_ms_ssim(originalGray, compressedGray, width, height, width, 0);
-                info("ms-ssim");
-                break;
-            case METHOD_SMALLFRY:
-                metric = smallfry_metric(originalGray, compressedGray, width, height);
-                info("smallfry");
-                break;
-            case METHOD_MPE:
-                metric = meanPixelError(originalGray, compressedGray, width, height, 1);
-                info("mpe");
-                break;
-            case METHOD_SSIM: default:
-                metric = iqa_ssim(originalGray, compressedGray, width, height, width, 0, 0);
-                info("ssim");
-                break;
-        }
-
-        if (attempt) {
-            info(" at q=%i (%i - %i): %f\n", quality, min, max, metric);
-        } else {
-            info(" at q=%i: %f\n", quality, metric);
-        }
-
-        if (metric < options.target) {
-            if (compressedSize >= bufSize) {
-                free(compressed);
-                free(compressedGray);
-
-                if (options.copyFiles) {
-                    info("Output file would be larger than input!\n");
-                    file = openOutput(cmd.argv[1]);
-                    if (file == NULL) {
-                        fprintf(stderr, "Could not open output file.");
-                        return 1;
-                    }
-
-                    fwrite(buf, bufSize, 1, file);
-                    fclose(file);
-
-                    free(buf);
-
-                    return 0;
-                } else {
-                    fprintf(stderr, "Output file would be larger than input!\n");
-                    free(buf);
-                    return 1;
-                }
-            }
-
-            switch (options.method) {
-                case METHOD_SSIM: case METHOD_MS_SSIM: case METHOD_SMALLFRY:
-                    // Too distorted, increase quality
-                    min = quality + 1;
-                    break;
-                case METHOD_MPE:
-                    // Higher than required, decrease quality
-                    max = quality - 1;
-                    break;
-            }
-        } else {
-            switch (options.method) {
-                case METHOD_SSIM: case METHOD_MS_SSIM: case METHOD_SMALLFRY:
-                    // Higher than required, decrease quality
-                    max = quality - 1;
-                    break;
-                case METHOD_MPE:
-                    // Too distorted, increase quality
-                    min = quality + 1;
-                    break;
-            }
-        }
-
-        // If we aren't done yet, then free the image data
-        if (attempt) {
-            free(compressed);
-            free(compressedGray);
-        }
-    }
-
-    free(buf);
-
-    // Calculate and show savings, if any
-    int percent = (compressedSize + metaSize) * 100 / bufSize;
-    unsigned long saved = (bufSize > compressedSize) ? bufSize - compressedSize - metaSize : 0;
-    info("New size is %i%% of original (saved %lu kb)\n", percent, saved / 1024);
-
-    if (compressedSize >= bufSize) {
-        fprintf(stderr, "Output file is larger than input, aborting!\n");
-        return 1;
-    }
-
-    // Open output file for writing
-    file = openOutput(cmd.argv[1]);
-    if (file == NULL) {
-        fprintf(stderr, "Could not open output file.");
-        return 1;
-    }
-
-    /* Check that the metadata starts with a SOI marker. */
-    if (!checkJpegMagic(compressed, compressedSize)) {
-        fprintf(stderr, "Missing SOI marker, aborting!\n");
-        return 1;
-    }
-
-    /* Make sure APP0 is recorded immediately after the SOI marker. */
-    if (compressed[2] != 0xff || compressed[3] != 0xe0) {
-        fprintf(stderr, "Missing APP0 marker, aborting!\n");
-        return 1;
-    }
-
-    /* Write SOI marker and APP0 metadata to the output file. */
-    int app0_len = (compressed[4] << 8) + compressed[5];
-    fwrite(compressed, 4 + app0_len, 1, file);
-
-    /*
-     * Write comment (COM metadata) so we know not to reprocess this file in
-     * the future if it gets passed in again.
-     */
-    fputc(0xff, file);
-    fputc(0xfe, file);
-    fputc(0x00, file);
-    fputc(strlen(COMMENT) + 2, file);
-    fwrite(COMMENT, strlen(COMMENT), 1, file);
-
-    /* Write additional metadata markers. */
-    if (inputFiletype == FILETYPE_JPEG && !options.strip) {
-        fwrite(metaBuf, metaSize, 1, file);
-    }
-
-    /* Write image data. */
-    fwrite(compressed + 4 + app0_len, compressedSize - 4 - app0_len, 1, file);
-    fclose(file);
+    recompress_error_t **error = malloc(sizeof(recompress_error_t *));
+    bool res = recompress(cmd.argv[0], cmd.argv[1], &options, error);
 
     /* Cleanup. */
     command_free(&cmd);
 
-    if (inputFiletype == FILETYPE_JPEG && !options.strip) {
-        free(metaBuf);
+    if (!res) {
+        int code = (*error)->statusCode;
+        fprintf(stderr, (*error)->message);
+        free(*error);
+        free(error);
+        return code;
     }
 
-    free(compressed);
-    free(original);
-    free(originalGray);
-
+    free(error);
     return 0;
 }

--- a/src/recompress.c
+++ b/src/recompress.c
@@ -1,0 +1,404 @@
+
+#include <assert.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "edit.h"
+#include "iqa/include/iqa.h"
+#include "recompress.h"
+#include "smallfry.h"
+#include "util.h"
+
+#ifdef _WIN32
+    #include <fcntl.h>
+    #include <io.h>
+#endif
+
+const char *COMMENT = "Compressed by jpeg-recompress";
+
+// Open a file for writing
+static FILE *openOutput(const char *name) {
+    if (strcmp("-", name) == 0) {
+        #ifdef _WIN32
+            setmode(fileno(stdout), O_BINARY);
+        #endif
+
+        return stdout;
+    } else {
+        return fopen(name, "wb");
+    }
+}
+
+// Quiet mode (less output)
+char quiet = false;
+
+// Logs an informational message, taking quiet mode into account
+static void info(const char *format, ...) {
+    va_list argptr;
+
+    if (!quiet) {
+        va_start(argptr, format);
+        vfprintf(stderr, format, argptr);
+        va_end(argptr);
+    }
+}
+
+static float getTargetFromPreset(enum METHOD method,
+                                 enum QUALITY_PRESET preset) {
+    switch (method) {
+        case METHOD_SSIM:
+            switch (preset) {
+                case QUALITY_LOW:
+                    return 0.999;
+                case QUALITY_MEDIUM:
+                    return 0.9999;
+                case QUALITY_HIGH:
+                    return 0.99995;
+                case QUALITY_VERYHIGH:
+                    return 0.99999;
+            }
+            break;
+        case METHOD_MS_SSIM:
+            switch (preset) {
+                case QUALITY_LOW:
+                    return 0.85;
+                case QUALITY_MEDIUM:
+                    return 0.94;
+                case QUALITY_HIGH:
+                    return 0.96;
+                case QUALITY_VERYHIGH:
+                    return 0.98;
+            }
+            break;
+        case METHOD_SMALLFRY:
+            switch (preset) {
+                case QUALITY_LOW:
+                    return 100.75;
+                case QUALITY_MEDIUM:
+                    return 102.25;
+                case QUALITY_HIGH:
+                    return 103.8;
+                case QUALITY_VERYHIGH:
+                    return 105.5;
+            }
+            break;
+        case METHOD_MPE:
+            switch (preset) {
+                case QUALITY_LOW:
+                    return 1.5;
+                case QUALITY_MEDIUM:
+                    return 1.0;
+                case QUALITY_HIGH:
+                    return 0.8;
+                case QUALITY_VERYHIGH:
+                    return 0.6;
+            }
+            break;
+        case METHOD_UNKNOWN:
+            // Fails below.
+            break;
+    }
+    assert(0 && "should be unreachable. All cases handled?");
+    return 0.0;
+}
+
+// Constructs the error struct used for reporting and return values to the
+// console. This function returns `false` as a convenience for the `recompress`
+// function.
+static bool err(recompress_error_t **error, const int statusCode,
+                const char *format, ...) {
+    va_list argptr;
+
+    if (!error) {
+        return false;
+    }
+
+    *error = malloc(sizeof(recompress_error_t));
+    assert(*error);
+
+    (*error)->statusCode = statusCode;
+    va_start(argptr, format);
+    int s = vsnprintf((*error)->message, ERROR_MESSAGE_MAX_LENGTH,
+                      format, argptr);
+    (*error)->message[s] = '\0';  // Just to be safe.
+    va_end(argptr);
+    return false;
+}
+
+bool recompress(const char *input, const char *output,
+                const recompress_options_t *options,
+                recompress_error_t **error) {
+    assert(input && strlen(input) > 0);
+    assert(output && strlen(output) > 0);
+    assert(options);
+    assert(options->method != METHOD_UNKNOWN);
+
+    unsigned char *buf;
+    long bufSize = 0;
+    unsigned char *original;
+    long originalSize = 0;
+    unsigned char *originalGray = NULL;
+    long originalGraySize = 0;
+    unsigned char *compressed = NULL;
+    unsigned long compressedSize = 0;
+    unsigned char *compressedGray;
+    long compressedGraySize = 0;
+    unsigned char *tmpImage;
+    int width, height;
+    unsigned char *metaBuf;
+    unsigned int metaSize = 0;
+    FILE *file;
+
+    /* Detect input file type. */
+    enum filetype inputFiletype = options->inputFiletype == FILETYPE_AUTO
+            ? detectFiletype(input)
+            : options->inputFiletype;
+
+    // No target passed, use preset!
+    float target = !options->target
+            ? getTargetFromPreset(options->method, options->preset)
+            : options->target;
+
+    /*
+    * Read original image and decode. We need the raw buffer contents and
+    * its size to obtain meta data and the original file size later.
+    */
+    bufSize = readFile(input, (void **)&buf);
+    originalSize = decodeFile(input, &original, inputFiletype, &width, &height,
+                              JCS_RGB);
+    if (!originalSize) {
+        return err(error, 1, "invalid input file: %s\n", input);
+    }
+
+    if (options->defishStrength) {
+        info("Defishing...\n");
+        tmpImage = malloc(width * height * 3);
+        assert(tmpImage);
+        defish(original, tmpImage, width, height, 3, options->defishStrength,
+               options->defishZoom);
+        free(original);
+        original = tmpImage;
+    }
+
+    // Convert RGB input into Y
+    originalGraySize = grayscale(original, &originalGray, width, height);
+
+    if (inputFiletype == FILETYPE_JPEG) {
+        // Read metadata (EXIF / IPTC / XMP tags)
+        if (getMetadata(buf, bufSize, &metaBuf, &metaSize, COMMENT)) {
+            if (options->copyFiles) {
+                info("File already processed by jpeg-recompress!\n");
+                file = openOutput(output);
+                if (file == NULL) {
+                    return err(error, 1, "Could not open output file.");
+                }
+
+                fwrite(buf, bufSize, 1, file);
+                fclose(file);
+
+                free(buf);
+
+                return true;
+            } else {
+                err(error, 2, "File already processed by jpeg-recompress!\n");
+                free(buf);
+                return false;
+            }
+        }
+    }
+
+    if (options->strip) {
+        // Pretend we have no metadata
+        metaSize = 0;
+    } else {
+        info("Metadata size is %ukb\n", metaSize / 1024);
+    }
+
+    if (!originalSize || !originalGraySize) {
+        return err(error, 1, "Missing original sizes");
+    }
+
+    // Do a binary search to find the optimal encoding quality for the
+    // given target SSIM value.
+    int min = options->jpegMin, max = options->jpegMax;
+    for (int attempt = options->attempts - 1; attempt >= 0; --attempt) {
+        float metric;
+        int quality = min + (max - min) / 2;
+        int progressive = attempt ? 0 : !options->noProgressive;
+        int optimize = options->accurate ? 1 : (attempt ? 0 : 1);
+
+        // Recompress to a new quality level, without optimizations (for speed)
+        compressedSize =
+            encodeJpeg(&compressed, original, width, height, JCS_RGB, quality,
+                        progressive, optimize, options->subsample);
+
+        // Load compressed luma for quality comparison
+        compressedGraySize =
+            decodeJpeg(compressed, compressedSize, &compressedGray, &width,
+                        &height, JCS_GRAYSCALE);
+
+        if (!compressedGraySize) {
+            return err(error, 1,
+                       "Unable to decode file that was just encoded!\n");
+        }
+
+        if (!attempt) {
+            info("Final optimized ");
+        }
+
+        // Measure quality difference
+        switch (options->method) {
+            case METHOD_MS_SSIM:
+                metric = iqa_ms_ssim(originalGray, compressedGray, width,
+                                    height, width, 0);
+                info("ms-ssim");
+                break;
+            case METHOD_SMALLFRY:
+                metric = smallfry_metric(originalGray, compressedGray, width,
+                                         height);
+                info("smallfry");
+                break;
+            case METHOD_MPE:
+                metric =
+                    meanPixelError(originalGray, compressedGray, width, height,
+                                   1);
+                info("mpe");
+                break;
+            case METHOD_SSIM:
+            default:
+                metric = iqa_ssim(originalGray, compressedGray, width, height,
+                                  width, 0, 0);
+                info("ssim");
+                break;
+        }
+
+        if (attempt) {
+            info(" at q=%i (%i - %i): %f\n", quality, min, max, metric);
+        } else {
+            info(" at q=%i: %f\n", quality, metric);
+        }
+
+        if (metric < target) {
+            if (compressedSize >= bufSize) {
+                free(compressed);
+                free(compressedGray);
+
+                if (options->copyFiles) {
+                    info("Output file would be larger than input!\n");
+                    file = openOutput(output);
+                    if (file == NULL) {
+                        return err(error, 1, "Could not open output file.");
+                    }
+
+                    fwrite(buf, bufSize, 1, file);
+                    fclose(file);
+
+                    free(buf);
+
+                    return true;
+                } else {
+                    err(error, 1, "Output file would be larger than input!\n");
+                    free(buf);
+                    return false;
+                }
+            }
+
+            switch (options->method) {
+                case METHOD_SSIM:
+                case METHOD_MS_SSIM:
+                case METHOD_SMALLFRY:
+                    // Too distorted, increase quality
+                    min = quality + 1;
+                    break;
+                case METHOD_MPE:
+                    // Higher than required, decrease quality
+                    max = quality - 1;
+                    break;
+            }
+        } else {
+            switch (options->method) {
+                case METHOD_SSIM:
+                case METHOD_MS_SSIM:
+                case METHOD_SMALLFRY:
+                    // Higher than required, decrease quality
+                    max = quality - 1;
+                    break;
+                case METHOD_MPE:
+                    // Too distorted, increase quality
+                    min = quality + 1;
+                    break;
+            }
+        }
+
+        // If we aren't done yet, then free the image data
+        if (attempt) {
+            free(compressed);
+            free(compressedGray);
+        }
+    }
+
+    free(buf);
+
+    // Calculate and show savings, if any
+    int percent = (compressedSize + metaSize) * 100 / bufSize;
+    unsigned long saved =
+        (bufSize > compressedSize) ? bufSize - compressedSize - metaSize : 0;
+    info("New size is %i%% of original (saved %lu kb)\n", percent,
+         saved / 1024);
+
+    if (compressedSize >= bufSize) {
+        return err(error, 1, "Output file is larger than input, aborting!\n");
+    }
+
+    // Open output file for writing
+    file = openOutput(output);
+    if (file == NULL) {
+        return err(error, 1, "Could not open output file.");
+    }
+
+    /* Check that the metadata starts with a SOI marker. */
+    if (!checkJpegMagic(compressed, compressedSize)) {
+        return err(error, 1, "Missing SOI marker, aborting!\n");
+    }
+
+    /* Make sure APP0 is recorded immediately after the SOI marker. */
+    if (compressed[2] != 0xff || compressed[3] != 0xe0) {
+        return err(error, 1, "Missing APP0 marker, aborting!\n");
+    }
+
+    /* Write SOI marker and APP0 metadata to the output file. */
+    int app0_len = (compressed[4] << 8) + compressed[5];
+    fwrite(compressed, 4 + app0_len, 1, file);
+
+    /*
+     * Write comment (COM metadata) so we know not to reprocess this file in
+     * the future if it gets passed in again.
+     */
+    fputc(0xff, file);
+    fputc(0xfe, file);
+    fputc(0x00, file);
+    fputc(strlen(COMMENT) + 2, file);
+    fwrite(COMMENT, strlen(COMMENT), 1, file);
+
+    /* Write additional metadata markers. */
+    if (inputFiletype == FILETYPE_JPEG && !options->strip) {
+        fwrite(metaBuf, metaSize, 1, file);
+    }
+
+    /* Write image data. */
+    fwrite(compressed + 4 + app0_len, compressedSize - 4 - app0_len, 1, file);
+    fclose(file);
+
+    if (inputFiletype == FILETYPE_JPEG && !options->strip) {
+        free(metaBuf);
+    }
+
+    free(compressed);
+    free(original);
+    free(originalGray);
+
+    return true;
+}

--- a/src/recompress.c
+++ b/src/recompress.c
@@ -39,6 +39,7 @@ static void info(char quiet, const char *format, ...) {
   if (!quiet) {
     va_start(argptr, format);
     vfprintf(stderr, format, argptr);
+    fprintf(stderr, "\n");
     va_end(argptr);
   }
 }
@@ -167,11 +168,11 @@ bool recompress(const char *input, const char *output,
     originalSize = decodeFile(input, &original, inputFiletype, &width, &height,
                               JCS_RGB);
     if (!originalSize) {
-        return err(error, 1, "invalid input file: %s\n", input);
+        return err(error, 1, "invalid input file: %s", input);
     }
 
     if (options->defishStrength) {
-        info(options->quiet, "Defishing...\n");
+        info(options->quiet, "Defishing...");
         tmpImage = malloc(width * height * 3);
         assert(tmpImage);
         defish(original, tmpImage, width, height, 3, options->defishStrength,
@@ -188,7 +189,7 @@ bool recompress(const char *input, const char *output,
         if (getMetadata(buf, bufSize, &metaBuf, &metaSize, COMMENT)) {
             if (options->copyFiles) {
                 info(options->quiet,
-                     "File already processed by jpeg-recompress!\n");
+                     "File already processed by jpeg-recompress!");
                 file = openOutput(output);
                 if (file == NULL) {
                     return err(error, 1, "Could not open output file.");
@@ -201,7 +202,7 @@ bool recompress(const char *input, const char *output,
 
                 return true;
             } else {
-                err(error, 2, "File already processed by jpeg-recompress!\n");
+                err(error, 2, "File already processed by jpeg-recompress!");
                 free(buf);
                 return false;
             }
@@ -212,7 +213,7 @@ bool recompress(const char *input, const char *output,
         // Pretend we have no metadata
         metaSize = 0;
     } else {
-        info(options->quiet, "Metadata size is %ukb\n", metaSize / 1024);
+        info(options->quiet, "Metadata size is %ukb", metaSize / 1024);
     }
 
     if (!originalSize || !originalGraySize) {
@@ -240,7 +241,7 @@ bool recompress(const char *input, const char *output,
 
         if (!compressedGraySize) {
             return err(error, 1,
-                       "Unable to decode file that was just encoded!\n");
+                       "Unable to decode file that was just encoded!");
         }
 
         if (!attempt) {
@@ -274,10 +275,10 @@ bool recompress(const char *input, const char *output,
         }
 
         if (attempt) {
-            info(options->quiet, " at q=%i (%i - %i): %f\n",
+            info(options->quiet, " at q=%i (%i - %i): %f",
                  quality, min, max, metric);
         } else {
-            info(options->quiet, " at q=%i: %f\n", quality, metric);
+            info(options->quiet, " at q=%i: %f", quality, metric);
         }
 
         if (metric < target) {
@@ -287,7 +288,7 @@ bool recompress(const char *input, const char *output,
 
                 if (options->copyFiles) {
                     info(options->quiet,
-                         "Output file would be larger than input!\n");
+                         "Output file would be larger than input!");
                     file = openOutput(output);
                     if (file == NULL) {
                         return err(error, 1, "Could not open output file.");
@@ -300,7 +301,7 @@ bool recompress(const char *input, const char *output,
 
                     return true;
                 } else {
-                    err(error, 1, "Output file would be larger than input!\n");
+                    err(error, 1, "Output file would be larger than input!");
                     free(buf);
                     return false;
                 }
@@ -346,11 +347,11 @@ bool recompress(const char *input, const char *output,
     int percent = (compressedSize + metaSize) * 100 / bufSize;
     unsigned long saved =
         (bufSize > compressedSize) ? bufSize - compressedSize - metaSize : 0;
-    info(options->quiet, "New size is %i%% of original (saved %lu kb)\n",
+    info(options->quiet, "New size is %i%% of original (saved %lu kb)",
          percent, saved / 1024);
 
     if (compressedSize >= bufSize) {
-        return err(error, 1, "Output file is larger than input, aborting!\n");
+        return err(error, 1, "Output file is larger than input, aborting!");
     }
 
     // Open output file for writing
@@ -361,12 +362,12 @@ bool recompress(const char *input, const char *output,
 
     /* Check that the metadata starts with a SOI marker. */
     if (!checkJpegMagic(compressed, compressedSize)) {
-        return err(error, 1, "Missing SOI marker, aborting!\n");
+        return err(error, 1, "Missing SOI marker, aborting!");
     }
 
     /* Make sure APP0 is recorded immediately after the SOI marker. */
     if (compressed[2] != 0xff || compressed[3] != 0xe0) {
-        return err(error, 1, "Missing APP0 marker, aborting!\n");
+        return err(error, 1, "Missing APP0 marker, aborting!");
     }
 
     /* Write SOI marker and APP0 metadata to the output file. */

--- a/src/recompress.h
+++ b/src/recompress.h
@@ -1,0 +1,60 @@
+/*
+    Recompress JPEG images
+*/
+#ifndef RECOMPRESS_H
+#define RECOMPRESS_H
+
+#include <stdbool.h>
+
+#include "util.h"
+
+// Comparison method
+enum METHOD {
+    METHOD_UNKNOWN,
+    METHOD_SSIM,
+    METHOD_MS_SSIM,
+    METHOD_SMALLFRY,
+    METHOD_MPE
+};
+
+// Target quality (SSIM) value
+enum QUALITY_PRESET {
+    QUALITY_LOW,
+    QUALITY_MEDIUM,
+    QUALITY_HIGH,
+    QUALITY_VERYHIGH
+};
+
+/*
+ *  Options used to recompress images.
+ */
+
+typedef struct {
+    enum METHOD method;
+    // Number of binary search steps
+    int attempts;
+    float target;
+    enum QUALITY_PRESET preset;
+    // Min/max JPEG quality
+    int jpegMin;
+    int jpegMax;
+    // Strip metadata from the file?
+    bool strip;
+    // Disable progressive mode?
+    bool noProgressive;
+    // Defish the image?
+    float defishStrength;
+    float defishZoom;
+    // Input format
+    enum filetype inputFiletype;
+    // Whether to copy files that cannot be compressed
+    bool copyFiles;
+    // Whether to favor accuracy over speed
+    bool accurate;
+    // Chroma subsampling method
+    enum SUBSAMPLING_METHOD subsample;
+    // Quiet mode (less output)
+    bool quiet;
+} recompress_options_t;
+
+#endif

--- a/src/recompress.h
+++ b/src/recompress.h
@@ -8,6 +8,8 @@
 
 #include "util.h"
 
+#define ERROR_MESSAGE_MAX_LENGTH 1024
+
 // Comparison method
 enum METHOD {
     METHOD_UNKNOWN,
@@ -56,5 +58,25 @@ typedef struct {
     // Quiet mode (less output)
     bool quiet;
 } recompress_options_t;
+
+/*
+ * Error information for a failed recompress.
+ */
+
+typedef struct {
+    int statusCode;
+    char message[ERROR_MESSAGE_MAX_LENGTH];
+} recompress_error_t;
+
+/*
+    Recompress a JPEG file while attempting to keep visual quality the same
+    by using structural similarity (SSIM) as a metric. Does a binary search
+    between JPEG quality 40 and 95 to find the best match. Also makes sure
+    that huffman tables are optimized if they weren't already.
+*/
+
+bool recompress(const char *input, const char *output,
+                const recompress_options_t *options,
+                recompress_error_t **error);
 
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -13,7 +13,7 @@
 
 const char *VERSION = "2.1.1";
 
-long readFile(char *name, void **buffer) {
+long readFile(const char *name, void **buffer) {
     FILE *file;
     size_t fileLen = 0;
     size_t bytesRead = 0;
@@ -255,7 +255,7 @@ enum filetype detectFiletype(const char *filename) {
     long bufSize = 0;
     enum filetype ret = FILETYPE_UNKNOWN;
 
-    bufSize = readFile((char *)filename, (void **)&buf);
+    bufSize = readFile(filename, (void **)&buf);
 
     if (checkJpegMagic(buf, bufSize))
         ret = FILETYPE_JPEG;
@@ -271,7 +271,7 @@ unsigned long decodeFile(const char *filename, unsigned char **image, enum filet
     long bufSize = 0;
     long ret = 0;
 
-    bufSize = readFile((char *)filename, (void **)&buf);
+    bufSize = readFile(filename, (void **)&buf);
 
     if (!bufSize)
         return 0;

--- a/src/util.h
+++ b/src/util.h
@@ -34,7 +34,7 @@ enum filetype {
 /*
     Read a file into a buffer and return the length.
 */
-long readFile(char *name, void **buffer);
+long readFile(const char *name, void **buffer);
 
 /*
     Decode a buffer into a JPEG image with the given pixel format.


### PR DESCRIPTION
This pull request splits out the recompression logic in `jpeg-recompress.c` into its own source file.

The reason I want to do this is I'm interested in building a Go app that will recompress JPEG files in-place and in parallel. I have a [prototype of that working](https://github.com/pope/jpeg-archive/blob/go-app/jpeg-archive-inplace.go), but don't worry, that's not in this request. I know I could use `jpeg-archive` or just do a child execution of `jpeg-recompress`, but I wanted one deliverable binary.

In addition to extracting the library, I did the following:

- Added `*.exe` to `.gitignore`.
- Added `.editorconfig` file to ensure consistent use of spaces/tabs.
- Updated `Makefile` to account to 64 bit builds of MozJPEG on Linux
- Updated `readFile` signature to take a `const char *` to avoid unnecessary casting.

*Testing*

I've tested on 64bit Linux and Windows 10.
