### PR TITLE
Only read input once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ comparison
 comparison.png
 test/test.jpg
 test/test
+.DS_Store

--- a/jpeg-recompress.c
+++ b/jpeg-recompress.c
@@ -322,16 +322,21 @@ int main (int argc, char **argv) {
         setTargetFromPreset();
     }
 
+    char *inputPath = (char *) cmd.argv[0];
+    char *outputPath = cmd.argv[1];
+
+    // Read the input into a buffer
+    bufSize = readFile(inputPath, (void **) &buf);
+
     /* Detect input file type. */
     if (inputFiletype == FILETYPE_AUTO)
-        inputFiletype = detectFiletype((char *) cmd.argv[0]);
+        inputFiletype = detectFiletypeFromBuffer(buf, bufSize);
 
     /*
      * Read original image and decode. We need the raw buffer contents and its
      * size to obtain meta data and the original file size later.
      */
-    bufSize = readFile((char *) cmd.argv[0], (void **) &buf);
-    originalSize = decodeFile((char *) cmd.argv[0], &original, inputFiletype, &width, &height, JCS_RGB);
+    originalSize = decodeFileFromBuffer(buf, bufSize, &original, inputFiletype, &width, &height, JCS_RGB);
     if (!originalSize) {
         fprintf(stderr, "invalid input file: %s\n", cmd.argv[0]);
         return 1;
@@ -353,7 +358,7 @@ int main (int argc, char **argv) {
         if (getMetadata(buf, bufSize, &metaBuf, &metaSize, COMMENT)) {
             if (copyFiles) {
                 info("File already processed by jpeg-recompress!\n");
-                file = openOutput(cmd.argv[1]);
+                file = openOutput(outputPath);
                 if (file == NULL) {
                     fprintf(stderr, "Could not open output file.");
                     return 1;

--- a/src/util.c
+++ b/src/util.c
@@ -276,6 +276,17 @@ enum filetype detectFiletype(const char *filename) {
     return ret;
 }
 
+enum filetype detectFiletypeFromBuffer(unsigned char *buf, long bufSize) {
+    enum filetype ret = FILETYPE_UNKNOWN;
+
+    if (checkJpegMagic(buf, bufSize))
+        ret = FILETYPE_JPEG;
+    else if (checkPpmMagic(buf, bufSize))
+        ret = FILETYPE_PPM;
+
+    return ret;
+}
+
 unsigned long decodeFile(const char *filename, unsigned char **image, enum filetype type, int *width, int *height, int pixelFormat) {
     unsigned char *buf = NULL;
     long bufSize = 0;
@@ -294,6 +305,22 @@ unsigned long decodeFile(const char *filename, unsigned char **image, enum filet
         ret = 0;
 
     free(buf);
+    return ret;
+}
+
+unsigned long decodeFileFromBuffer(unsigned char *buf, long bufSize, unsigned char **image, enum filetype type, int *width, int *height, int pixelFormat) {
+    long ret = 0;
+
+    if (!bufSize)
+        return 0;
+
+    if (type == FILETYPE_PPM)
+        ret = decodePpm(buf, bufSize, image, width, height);
+    else if (type == FILETYPE_JPEG)
+        ret = decodeJpeg(buf, bufSize, image, width, height, pixelFormat);
+    else
+        ret = 0;
+
     return ret;
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -263,65 +263,40 @@ unsigned long decodePpm(unsigned char *buf, unsigned long bufSize, unsigned char
 enum filetype detectFiletype(const char *filename) {
     unsigned char *buf = NULL;
     long bufSize = 0;
-    enum filetype ret = FILETYPE_UNKNOWN;
-
     bufSize = readFile((char *)filename, (void **)&buf);
-
-    if (checkJpegMagic(buf, bufSize))
-        ret = FILETYPE_JPEG;
-    else if (checkPpmMagic(buf, bufSize))
-        ret = FILETYPE_PPM;
-
+    enum filetype ret = detectFiletypeFromBuffer(buf, bufSize);
     free(buf);
     return ret;
 }
 
 enum filetype detectFiletypeFromBuffer(unsigned char *buf, long bufSize) {
-    enum filetype ret = FILETYPE_UNKNOWN;
-
     if (checkJpegMagic(buf, bufSize))
-        ret = FILETYPE_JPEG;
-    else if (checkPpmMagic(buf, bufSize))
-        ret = FILETYPE_PPM;
+        return FILETYPE_JPEG;
 
-    return ret;
+    if (checkPpmMagic(buf, bufSize))
+        return FILETYPE_PPM;
+
+    return FILETYPE_UNKNOWN;
 }
 
 unsigned long decodeFile(const char *filename, unsigned char **image, enum filetype type, int *width, int *height, int pixelFormat) {
     unsigned char *buf = NULL;
     long bufSize = 0;
-    long ret = 0;
-
     bufSize = readFile((char *)filename, (void **)&buf);
-
-    if (!bufSize)
-        return 0;
-
-    if (type == FILETYPE_PPM)
-        ret = decodePpm(buf, bufSize, image, width, height);
-    else if (type == FILETYPE_JPEG)
-        ret = decodeJpeg(buf, bufSize, image, width, height, pixelFormat);
-    else
-        ret = 0;
-
+    unsigned long ret = decodeFileFromBuffer(buf, bufSize, image, type, width, height, pixelFormat);
     free(buf);
     return ret;
 }
 
 unsigned long decodeFileFromBuffer(unsigned char *buf, long bufSize, unsigned char **image, enum filetype type, int *width, int *height, int pixelFormat) {
-    long ret = 0;
-
-    if (!bufSize)
-        return 0;
-
-    if (type == FILETYPE_PPM)
-        ret = decodePpm(buf, bufSize, image, width, height);
-    else if (type == FILETYPE_JPEG)
-        ret = decodeJpeg(buf, bufSize, image, width, height, pixelFormat);
-    else
-        ret = 0;
-
-    return ret;
+    switch(type) {
+        case FILETYPE_PPM:
+            return decodePpm(buf, bufSize, image, width, height);
+        case FILETYPE_JPEG:
+            return decodeJpeg(buf, bufSize, image, width, height, pixelFormat);
+        default:
+            return 0;
+    }
 }
 
 int getMetadata(const unsigned char *buf, unsigned int bufSize, unsigned char **meta, unsigned int *metaSize, const char *comment) {

--- a/src/util.h
+++ b/src/util.h
@@ -58,9 +58,11 @@ unsigned long encodeJpeg(unsigned char **jpeg, unsigned char *buf, int width, in
 
 /* Automatically detect the file type of a given file. */
 enum filetype detectFiletype(const char *filename);
+enum filetype detectFiletypeFromBuffer(unsigned char *buf, long bufSize);
 
 /* Decode an image file with a given format. */
 unsigned long decodeFile(const char *filename, unsigned char **image, enum filetype type, int *width, int *height, int pixelFormat);
+unsigned long decodeFileFromBuffer(unsigned char *buf, long bufSize, unsigned char **image, enum filetype type, int *width, int *height, int pixelFormat);
 
 /*
     Get JPEG metadata (EXIF, IPTC, XMP, etc) and return a buffer


### PR DESCRIPTION
I was having trouble using stdin/stdout for input/output to jpeg-recompress.

Digging a little bit deeper and with the help of @pope I realized that jpeg-recompress actually reads the input multiple times, so by the second read the input is already drained. This is why it works fine with files, but not with pipes/stdin.

The fix adds new `decodeFiletype` and `decodeFile` versions that take a buffer instead of reading the file themselves.