### PR TITLE
Update iqa Makefile to fix cross compilation

### DIFF
--- a/src/iqa/Makefile
+++ b/src/iqa/Makefile
@@ -11,7 +11,7 @@ SRC= \
 OBJ = $(SRC:.c=.o)
 
 INCLUDES = -I./include
-CC = gcc
+CC ?= gcc
 
 ifeq ($(RELEASE),1)
 OUTDIR=./build/release


### PR DESCRIPTION
gcc is set as default compiler in iqa Makefile, causing the build to fail when using a different compiler. Change the makefile to use the environment CC variable if it is set