### PR TITLE
No need to set the preset variable in parseQuality() function

### DIFF
--- a/jpeg-recompress.c
+++ b/jpeg-recompress.c
@@ -84,9 +84,9 @@ static enum QUALITY_PRESET parseQuality(const char *s) {
     else if (!strcmp("medium", s))
         return MEDIUM;
     else if (!strcmp("high", s))
-        return preset = HIGH;
+        return HIGH;
     else if (!strcmp("veryhigh", s))
-        return preset = VERYHIGH;
+        return VERYHIGH;
 
     error("unknown quality preset: %s", s);
     return MEDIUM;


### PR DESCRIPTION
because the preset variable is set by the caller of parseQuality() in line 282.

See this code snippet:
```
        case 'q':
            preset = parseQuality(optarg);
            break;
```