### PR TITLE
Attempt to fix heap buffer overflow in smallfry.

### DIFF
--- a/src/smallfry.c
+++ b/src/smallfry.c
@@ -93,7 +93,7 @@ static double aae_factor(uint8_t *orig, uint8_t *cmp, int orig_stride,
     old = orig + 7 * orig_stride;
     new = cmp  + 7 * cmp_stride;
 
-    for (i = 7; i < height - 1; i += 8) {
+    for (i = 7; i < height - 2; i += 8) {
         for (j = 0; j < width; j++) {
             double calc;
 


### PR DESCRIPTION
Fixes #24.

I believe this matches the intent of the original programmer, although I
am not at all sure.

Inside of this loop, HDVAL(j, 2) reads two strides (i.e. widths) past
the current location.  Therefore `height - 1` is not sufficient to keep
it in-bounds.