### PR TITLE
workaround for GCC 10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC ?= gcc
-CFLAGS += -std=c99 -Wall -O3 
+CFLAGS += -std=c99 -Wall -O3
 # workaround for GCC 10
 CFLAGS += -fcommon
 LDFLAGS += -lm

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 CC ?= gcc
-CFLAGS += -std=c99 -Wall -O3
+CFLAGS += -std=c99 -Wall -O3 
+# workaround for GCC 10
+CFLAGS += -fcommon
 LDFLAGS += -lm
 MAKE ?= make
 PREFIX ?= /usr/local


### PR DESCRIPTION
GCC 10 default to -fno-common which force use of extern with global variable. 
This revert the flag. See https://gcc.gnu.org/gcc-10/porting_to.html

Fix #119 