### PR TITLE
Make find case insensitive for *.jpg

### DIFF
--- a/jpeg-archive
+++ b/jpeg-archive
@@ -50,7 +50,7 @@ elif [ -n "$PARALLEL" ]; then
 		"$PARALLEL" --no-notice "exiftool -overwrite_original -TagsFromFile {} -all:all /tmp/comp/{.}.jpg"
 
 	echo 'Recompressing JPEG files'
-	find . -name '*.jpg' | \
+	find . -iname '*.jpg' | \
 		"$PARALLEL" --no-notice "mkdir -p /tmp/comp/{//}; jpeg-recompress ${@:--q high} {} /tmp/comp/{}"
 fi
 


### PR DESCRIPTION
My camera spits out DSC00000.JPG. I could lower case the file extension
or we can make the find case insensitive. Suggest the latter is the
better approach.