### PR TITLE
Fix for GCC 10 - avoid multiple definitions of variables (util.h)

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -13,6 +13,7 @@
 #define INPUT_BUFFER_SIZE 102400
 
 const char *VERSION = "2.2.0";
+const char *progname;
 
 /* Print program version to stdout. */
 void version(void) {

--- a/src/util.h
+++ b/src/util.h
@@ -11,8 +11,8 @@
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
-const char *VERSION;
-const char *progname;
+extern const char *VERSION;
+extern const char *progname;
 
 // Subsampling method, which defines how much of the data from
 // each color channel is included in the image per 2x2 block.


### PR DESCRIPTION
Fixes #119

> /usr/bin/ld: src/util.o:(.data+0x0): multiple definition of `VERSION';
>  /tmp/ccSwNFWH.o:(.bss+0x28): first defined here
> /usr/bin/ld: src/util.o:(.bss+0x0): multiple definition of `progname';
>  /tmp/ccSwNFWH.o:(.bss+0x20): first defined here
> collect2: error: ld returned 1 exit status